### PR TITLE
Get last release from REST API

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -11,20 +11,13 @@ function publish() {
   # See https://docs.github.com/en/actions/reference/environment-variables
   event_data=$(cat "$GITHUB_EVENT_PATH")
 
-  local releases_url
-  releases_url=$(echo "$event_data" | jq -r .releases_url)
-
-  local release_event_response
-  release_event_response="$(curl \
-    -X GET \
+  local upload_url
+  upload_url="$(curl \
     -H 'Content-Type: application/octet-stream' \
     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-    "${releases_url}" 2>> /dev/null)"
-
-  echo "${release_event_response}";
-
-  local upload_url
-  upload_url=$(echo "$event_data" | jq -r .release.upload_url)
+    https://api.github.com/repos/anode-co/AnodeVPN-android/releases 2>> /dev/null | \
+    jq -r '.[] | .upload_url' | \
+    head -n1)"
   upload_url=${upload_url/\{?name,label\}/}
 
   local release_name

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -7,10 +7,6 @@ function publish() {
   local checksum
   checksum=$(sha256sum ${apk} | cut -d ' ' -f 1)
 
-  local event_data
-  # See https://docs.github.com/en/actions/reference/environment-variables
-  event_data=$(cat "$GITHUB_EVENT_PATH")
-
   local upload_url
   upload_url="$(curl \
     -H 'Content-Type: application/octet-stream' \
@@ -21,7 +17,12 @@ function publish() {
   upload_url=${upload_url/\{?name,label\}/}
 
   local release_name
-  release_name=$(echo "$event_data" | jq -r .release.tag_name)
+  release_name="$(curl \
+    -H 'Content-Type: application/octet-stream' \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    https://api.github.com/repos/anode-co/AnodeVPN-android/releases 2>> /dev/null | \
+    jq -r '.[] | .tag_name' | \
+    head -n1)"
 
   curl \
     -X POST \


### PR DESCRIPTION
# Description

By running a workflow when a tag is pushed instead of on release creation,
the `$GITHUB_EVENT_PATH` environment is not needed anymore to extract
 - the last release upload URL (required to upload artificacts)
 - the last tag name (to name the artifacts) 
 
 Instead of using the webhook event information
 (on a tag being pushed or on a release being created), 
 the [`releases` related endpoint](https://docs.github.com/en/rest/reference/repos#releases) of the GitHub REST API is accessed.
 